### PR TITLE
Add advanced "options" to the "iobio-coverage-depth' chart

### DIFF
--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -113,6 +113,14 @@ const DEFAULT_OPTIONS = {
     showChromosomes: true,
     showYAxis: true,
     showYAxisLabel: true,
+    yAxisPosition: 'left',
+    averageCovLabelPosition: 'left-external',
+    margin: {
+        top: 0,
+        right: 20,
+        bottom: 20,
+        left: 0,
+    }
 }
 
 class BamViewChart extends HTMLElement {

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,6 +241,7 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
+                console.log('global brushed region updated manually');
                 this.updateBamView();
             });
         }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -108,22 +108,11 @@ rect {
 `;
 
 const DEFAULT_OPTIONS = {
-    showChartLabel: false,
-    showZoomableChart: false,
-    showChromosomes: false,
-    showAllButton: false,
+    showChartLabel: true,
+    showZoomableChart: true,
+    showChromosomes: true,
     showYAxis: true,
-    yAxisPosition: 'right', // 'left' or 'right'
-    averageCovLabelPosition: 'right-inside', // 'left-outside' 'right-outside' 'left-inside' 'right-inside'
-    showYAxisLabel: false,
-    margin: {
-        top: 8, //px
-        right: 0, //px
-        bottom: 8, //px
-        left: 0, //px
-    },
-    height: 100, //%
-    width: 100, //%
+    showYAxisLabel: true,
 }
 
 class BamViewChart extends HTMLElement {

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,8 +241,8 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
-                this.updateBamView();
-                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
+                // this.updateBamView();
+                // this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -112,6 +112,7 @@ const DEFAULT_OPTIONS = {
     showZoomableChart: true,
     showChromosomes: true,
     showYAxis: true,
+    showYAxisLine: true,
     showYAxisLabel: true,
     yAxisPosition: 'external', // 'external' or 'internal'
     averageCovLabelPosition: 'left-external', // 'left-external', 'right-external', 'left-internal', 'right-internal'

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,7 +241,7 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
-                this.updateBamView();
+                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,7 +241,7 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
-                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
+                this.updateBamView();
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -113,8 +113,8 @@ const DEFAULT_OPTIONS = {
     showChromosomes: true,
     showYAxis: true,
     showYAxisLabel: true,
-    yAxisPosition: 'left',
-    averageCovLabelPosition: 'left-external',
+    yAxisPosition: 'external', // 'external' or 'internal'
+    averageCovLabelPosition: 'left-external', // 'left-external', 'right-external', 'left-internal', 'right-internal'
     margin: {
         top: 0,
         right: 20,

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,7 +241,6 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
-                console.log('global brushed region updated manually');
                 this.updateBamView();
             });
         }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -107,6 +107,18 @@ rect {
 </div>
 `;
 
+const DEFAULT_OPTIONS = {
+    showChartLabel: false,
+    showZoomableChart: false,
+    showChromosomes: false,
+    showAllButton: false,
+    showYAxis: true,
+    showYAxisLabel: false,
+    margin: 0, //px
+    padding: 0, //px
+    height: 100, //%
+    width: 100, //%
+}
 
 class BamViewChart extends HTMLElement {
     constructor() {
@@ -118,7 +130,8 @@ class BamViewChart extends HTMLElement {
         this.bamHeader = null;
         this.validBamHeader = null;
         this.validBamReadDepth = null;
-        upgradeProperty(this, 'label');
+        upgradeProperty(this, 'label'); //Keeping as is for backwards compatability
+        upgradeProperty(this, 'options')
 
         this._regionStart = null;
         this._regionEnd = null;
@@ -134,6 +147,25 @@ class BamViewChart extends HTMLElement {
         this._meanCoverage = null;
     }
 
+    get options() {
+        const raw = this.getAttribute('options');
+        let parsed = {};
+        try {
+          parsed = raw ? JSON.parse(raw) : {};
+        } catch (e) {
+          console.warn('Invalid options JSON', raw);
+        }
+        //Return the merge of default options and parsed so that we always have the options even if not passed
+        return { ...DEFAULT_OPTIONS, ...parsed };
+    }
+
+    set options(val) {
+        //Sanitize the typing, we expect strings but want to be able to work with the options as a json/object
+        const str = typeof val === 'string' ? val : JSON.stringify(val);
+        this.setAttribute('options', str);
+    }
+
+    //Keeping label as is for backwards compatablility
     get label() {
         return this.getAttribute('label');
       }
@@ -160,6 +192,7 @@ class BamViewChart extends HTMLElement {
         this.broker = getDataBroker(this);
         
         if (this.label) {
+        const opts = this.options;
             this.shadowRoot.querySelector('#title-text').innerText = this.label;
         }
   

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -113,9 +113,15 @@ const DEFAULT_OPTIONS = {
     showChromosomes: false,
     showAllButton: false,
     showYAxis: true,
+    yAxisPosition: 'right', // 'left' or 'right'
+    averageCovLabelPosition: 'right-inside', // 'left-outside' 'right-outside' 'left-inside' 'right-inside'
     showYAxisLabel: false,
-    margin: 0, //px
-    padding: 0, //px
+    margin: {
+        top: 8, //px
+        right: 0, //px
+        bottom: 8, //px
+        left: 0, //px
+    },
     height: 100, //%
     width: 100, //%
 }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -238,6 +238,11 @@ class BamViewChart extends HTMLElement {
                 this._regionStartGlobal= event.detail.start;
                 this._regionEndGlobal = event.detail.end;
             });
+            document.addEventListener('global-brushed-region-update-manual', (event) => {
+                this._regionStartGlobal = event.detail.start;
+                this._regionEndGlobal = event.detail.end;
+                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
+            });
         }
     }
 

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -238,11 +238,6 @@ class BamViewChart extends HTMLElement {
                 this._regionStartGlobal= event.detail.start;
                 this._regionEndGlobal = event.detail.end;
             });
-            document.addEventListener('global-brushed-region-update-manual', (event) => {
-                this._regionStartGlobal = event.detail.start;
-                this._regionEndGlobal = event.detail.end;
-                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
-            });
         }
     }
 

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,6 +241,8 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
+                // this.updateBamView();
+                // this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,8 +241,8 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
-                console.log('global brushed region updated manually');
                 this.updateBamView();
+                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,8 +241,6 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
-                // this.updateBamView();
-                // this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,8 +241,8 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
-                // this.updateBamView();
-                // this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
+                this.updateBamView();
+                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -241,8 +241,8 @@ class BamViewChart extends HTMLElement {
             document.addEventListener('global-brushed-region-update-manual', (event) => {
                 this._regionStartGlobal = event.detail.start;
                 this._regionEndGlobal = event.detail.end;
+                console.log('global brushed region updated manually');
                 this.updateBamView();
-                this._bamView.updateBrushedRegion(this._regionStartGlobal, this._regionEndGlobal);
             });
         }
     }

--- a/coverage/src/BamView-WebComponent.js
+++ b/coverage/src/BamView-WebComponent.js
@@ -190,10 +190,12 @@ class BamViewChart extends HTMLElement {
     async connectedCallback() {
 
         this.broker = getDataBroker(this);
-        
-        if (this.label) {
         const opts = this.options;
+
+        if (this.label && opts.showChartLabel) {
             this.shadowRoot.querySelector('#title-text').innerText = this.label;
+        } else {
+            this.shadowRoot.querySelector('#title-container').remove()
         }
   
         if (this.broker) {
@@ -245,11 +247,12 @@ class BamViewChart extends HTMLElement {
     }
 
     updateBamView() {
+        const opts = this.options;
         this.validBamHeader = getValidRefs(this.bamHeader, this.bamReadDepth);
         this.validBamReadDepth = this.getBamReadDepthByValidRefs(this.validBamHeader, this.bamReadDepth);
 
         // Create the new BAM view
-        this._bamView = createBamView(this.validBamHeader, this.validBamReadDepth, this.bamViewContainer);
+        this._bamView = createBamView(this.validBamHeader, this.validBamReadDepth, this.bamViewContainer, opts);
 
         this.setupResizeObserver();
     }
@@ -264,11 +267,12 @@ class BamViewChart extends HTMLElement {
 
     setupResizeObserver() {
         let resizeTimeout;
+        const opts = this.options;
 
         // Resize observer to handle resizing of the BAM view chart
         const resizeHandler = () => {
             // Create the BAM view with the new dimensions of the container
-            this._bamView = createBamView(this.validBamHeader, this.validBamReadDepth, this.bamViewContainer);
+            this._bamView = createBamView(this.validBamHeader, this.validBamReadDepth, this.bamViewContainer, opts);
             this._bamView.updateMeanLineAndYaxis(this._meanCoverage);
 
             // Re-zoom to the region if a region on global view is brushed

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -18,16 +18,39 @@ function createBamView(bamHeader, data, container, options={}) {
     function createSvg(opts) {
         d3.select(container).selectAll("*").remove();
 
-        const width = container.offsetWidth;
-        const height = container.offsetHeight;
-        margin = { top: 60, right: 20, bottom: 20, left: 60 };
-        margin2 = { top: 10, right: 20, bottom: 20, left: 60 };
+        let width = container.offsetWidth;
+        let height = container.offsetHeight;
+
+        // Height and width are expected to be percentage of the container
+        if (opts.height) {
+            let calcHeight = (opts.height/100) * height;
+            height = calcHeight;
+        }
+        if (opts.width) {
+            let calcWidth = (opts.width/100) * width;
+            width = calcWidth;
+        }
+
+        // Set margins
+        if (opts.margin) {
+            margin = opts.margin;
+            margin2 = { top: 10, right: opts.margin.right, bottom: opts.margin.bottom, left: opts.margin.left };
+        } else {
+            margin = { top: 60, right: 20, bottom: 20, left: 60 };
+            margin2 = { top: 10, right: 20, bottom: 20, left: 60 };
+        }
+
         innerWidth = width - margin.left - margin.right;
         innerHeight = height - margin.top - margin.bottom;
 
-        // Split heights for main and navigation charts
-        navHeight = 0.2 * innerHeight;
-        mainHeight = innerHeight - navHeight - 10;
+        if (opts.showZoomableChart) {
+            // Split heights for main and navigation charts
+            navHeight = 0.2 * innerHeight;
+            mainHeight = innerHeight - navHeight - 10;
+        } else {
+            navHeight = 0;
+            mainHeight = innerHeight;
+        }
 
         // Create SVG container
         svg = d3.select(container)

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -21,20 +21,34 @@ function createBamView(bamHeader, data, container, options={}) {
         let width = container.offsetWidth;
         let height = container.offsetHeight;
 
-        // Height and width are expected to be percentage of the container
-        if (opts.height) {
-            let calcHeight = (opts.height/100) * height;
-            height = calcHeight;
-        }
-        if (opts.width) {
-            let calcWidth = (opts.width/100) * width;
-            width = calcWidth;
-        }
-
         // Set margins
         if (opts.margin) {
-            margin = opts.margin;
-            margin2 = { top: 10, right: opts.margin.right, bottom: opts.margin.bottom, left: opts.margin.left };
+            margin = {};
+            
+            // If we have a Y-axis label, an axis, or an average coverage label rendered externally to the left we need space for that
+            if (opts.showYLabel || (opts.showYAxis && opts.yAxisPosition && opts.yAxisPosition === 'external') || (opts.averageCovLabelPosition && opts.averageCovLabelPosition === 'left-external')) {
+                margin.left = opts.margin.left + 60;
+            } else {
+                margin.left = opts.margin.left;
+            }
+            
+            // If we render the average coverage label externally to the right we need space for that
+            if (opts.averageCovLabelPosition && opts.averageCovLabelPosition === 'right-external') {
+                margin.right = opts.margin.right + 30;
+            } else {
+                margin.right = opts.margin.right;
+            }
+
+            // If we have the chromosomes bar we have to have space for the bar and the all button to the top and left
+            if (opts.showChromosomes) {
+                margin.top = opts.margin.top + 40;
+                margin.left = opts.margin.left + 60;
+            } else {
+                margin.top = opts.margin.top;
+            }
+
+            margin.bottom = opts.margin.bottom;
+            margin2 = { top: 10, right: margin.right, bottom: margin.bottom, left: margin.left };
         } else {
             margin = { top: 60, right: 20, bottom: 20, left: 60 };
             margin2 = { top: 10, right: 20, bottom: 20, left: 60 };
@@ -193,7 +207,7 @@ function createBamView(bamHeader, data, container, options={}) {
                                 .range([navHeight, 0])
                                 .domain(yScale.domain());     
 
-            if (opts.showYLabel) {
+            if (opts.showYAxisLabel) {
                 // Append Y-axis label
                 svg.append('text')
                     .attr('class', 'y-axis-label')

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -370,17 +370,60 @@ function createBamView(bamHeader, data, container, options={}) {
                     .range([mainHeight, 0])
                     .domain([0, 2 * average / conversionRatio]);
 
-        // Y-axis
-        yAxis = d3.axisLeft(yAxis_scale)
+        console.log(opts.yAxisPosition);
+        if (opts.yAxisPosition && opts.yAxisPosition === 'internal') {
+            // Y-axis
+            yAxis = d3.axisRight(yAxis_scale)
                 .ticks(Math.floor(mainHeight / 20))
                 .tickSize(0)
                 .tickFormat(d => `${d}x`);
 
-        // Append Y-axis
-        svg.append('g')
-            .attr('class', 'y-axis')
-            .attr('transform', `translate(${margin.left}, ${margin.top})`)
-            .call(yAxis); 
+            // Append Y-axis (done inside of the logic so that we can also add our rectangles)
+            svg.append('g')
+                .attr('class', 'y-axis')
+                .attr('transform', `translate(${margin.left}, ${margin.top})`)
+                .call(yAxis);
+            
+            // Add rectangles for the y-axis
+            let ticks = svg.selectAll('.tick')
+            
+            // Add rectangles for each tick
+            ticks.each(function(d, i) {
+                const tick = d3.select(this);
+                const text = tick.select('text');
+
+                //the rect should just be where the text is
+                const rectWidth = text.node().getBBox().width + 10;
+                const rectHeight = 10;
+                const rectX = parseFloat(text.attr('x')) - rectWidth / 2;
+
+                tick.append('rect')
+                    .attr('class', 'tick-rect')
+                    .attr('x', `${rectX + 6}px`)
+                    .attr('y', `-${rectHeight/2}px`)
+                    .attr('width', rectWidth)
+                    .attr('height', rectHeight)
+                    .attr('fill', 'white')
+                    .attr('opacity', 0.5)
+                    .attr('rx', 3);
+                
+                //Raise the text above the rectangle
+                text.raise();
+            });
+
+        } else {
+            // Y-axis
+            yAxis = d3.axisLeft(yAxis_scale)
+                    .ticks(Math.floor(mainHeight / 20))
+                    .tickSize(0)
+                    .tickFormat(d => `${d}x`);
+            
+            // Append Y-axis 
+            svg.append('g')
+                .attr('class', 'y-axis')
+                .attr('transform', `translate(${margin.left}, ${margin.top})`)
+                .call(yAxis); 
+        }
 
         const meanLineGroup = svg.append('g')
             .attr('class', 'mean-line-group')

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -170,13 +170,15 @@ function createBamView(bamHeader, data, container, options={}) {
                                 .range([navHeight, 0])
                                 .domain(yScale.domain());     
 
-            // Append Y-axis label
-            svg.append('text')
-                .attr('class', 'y-axis-label')
-                .attr('transform', `translate(${margin.left - 40}, ${margin.top + mainHeight / 2}) rotate(-90)`)
-                .attr('text-anchor', 'middle')
-                .text('Coverage (rough estimate)')
-                .style('font-size', '12px');
+            if (opts.showYLabel) {
+                // Append Y-axis label
+                svg.append('text')
+                    .attr('class', 'y-axis-label')
+                    .attr('transform', `translate(${margin.left - 40}, ${margin.top + mainHeight / 2}) rotate(-90)`)
+                    .attr('text-anchor', 'middle')
+                    .text('Coverage (rough estimate)')
+                    .style('font-size', '12px');
+            }
 
             // Clip path
             svg.append('defs')

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -15,7 +15,7 @@ function createBamView(bamHeader, data, container, options={}) {
 
     const opts = options;
 
-    function createSvg() {
+    function createSvg(opts) {
         d3.select(container).selectAll("*").remove();
 
         const width = container.offsetWidth;
@@ -314,10 +314,17 @@ function createBamView(bamHeader, data, container, options={}) {
         
         // Draw the chart
         drawBarChart(svg);
-        // Create circle button for reset chromosomes and redraw the chart
-        drawCircleButton(svg);
-        // Draw reference buttons 
-        drawRefButtons(svg);
+
+        if (opts.showAllButton) {
+            // Create circle button for reset chromosomes and redraw the chart
+            drawCircleButton(svg);
+        }
+
+        if (opts.showChromosomes) {
+            // Draw reference buttons 
+            drawRefButtons(svg);            
+        }
+
     }
 
 
@@ -721,7 +728,7 @@ function createBamView(bamHeader, data, container, options={}) {
         shadowRoot.dispatchEvent(customEvent);
     }
 
-    createSvg()
+    createSvg(opts)
 
     return { zoomToChromomsomeRegion, updateMeanLineAndYaxis, updateBrushedRegion }
 }

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -340,14 +340,10 @@ function createBamView(bamHeader, data, container, options={}) {
         // Draw the chart
         drawBarChart(svg);
 
-        if (opts.showAllButton) {
-            // Create circle button for reset chromosomes and redraw the chart
-            drawCircleButton(svg);
-        }
-
         if (opts.showChromosomes) {
             // Draw reference buttons 
-            drawRefButtons(svg);            
+            drawRefButtons(svg);   
+            drawCircleButton(svg);         
         }
 
     }

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -21,7 +21,7 @@ function createBamView(bamHeader, data, container, options={}) {
         let width = container.offsetWidth;
         let height = container.offsetHeight;
 
-        // Set margins
+        // Set margins based on options and user specified values
         if (opts.margin) {
             margin = {};
             

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -369,21 +369,12 @@ function createBamView(bamHeader, data, container, options={}) {
         const yAxis_scale = d3.scaleLinear()
                     .range([mainHeight, 0])
                     .domain([0, 2 * average / conversionRatio]);
-        
-        if (opts.yAxisPosition && opts.yAxisPosition === 'right') {
-            // Y-axis
-            yAxis = d3.axisRight(yAxis_scale)
-                .ticks(Math.floor(mainHeight / 20))
-                .tickSize(0)
-                .tickFormat(d => `${d}x`);
 
-        } else {
-            // Y-axis
-            yAxis = d3.axisLeft(yAxis_scale)
+        // Y-axis
+        yAxis = d3.axisLeft(yAxis_scale)
                 .ticks(Math.floor(mainHeight / 20))
                 .tickSize(0)
                 .tickFormat(d => `${d}x`);
-        }
 
         // Append Y-axis
         svg.append('g')
@@ -407,42 +398,10 @@ function createBamView(bamHeader, data, container, options={}) {
             .attr('stroke-dasharray', '3,3')
             .attr('z-index', 1000);
 
-        // If we are on the inside of the chart we need to add a white rectangle behind the mean line label
-        if (opts.averageCovLabelPosition === 'left-inside' || opts.averageCovLabelPosition === 'right-inside') {
-            meanLineGroup.append('rect')
-                .attr('x', function() {
-                    if (opts.averageCovLabelPosition === 'left-inside') {
-                        return 10 + 'px';
-                    } else if (opts.averageCovLabelPosition === 'right-inside') {
-                        return innerWidth - 32 + 'px';
-                    }
-                })
-                .attr('y', yAxis_scale(meanCoverage) - 10)
-                .attr('width', 25)
-                .attr('height', 20)
-                .style('fill', 'white')
-                .style('opacity', 0.7)
-                .attr('rx', 5);
-        }
-
         // label for mean line
         meanLineGroup.append('text')
             .attr('class', 'mean-label')
-            .attr('x', function() {
-                if (opts.averageCovLabelPosition) {
-                    if (opts.averageCovLabelPosition === 'left-outside') {
-                        return 0 + 'px';
-                    } else if (opts.averageCovLabelPosition === 'right-outside') {
-                        return innerWidth + 'px';
-                    } else if (opts.averageCovLabelPosition === 'left-inside') {
-                        return 10 + 'px';
-                    } else if (opts.averageCovLabelPosition === 'right-inside') {
-                        return innerWidth - 10 + 'px';
-                    }
-                } else {
-                    return 0 + 'px';
-                }
-            })
+            .attr('x', 0)
             .attr('y', yAxis_scale(meanCoverage))
             .attr('dy', "0.35em") 
             .attr('text-anchor', 'end') 

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -380,58 +380,65 @@ function createBamView(bamHeader, data, container, options={}) {
                     .range([mainHeight, 0])
                     .domain([0, 2 * average / conversionRatio]);
 
-        if (opts.yAxisPosition && opts.yAxisPosition === 'internal') {
-            // Y-axis
-            yAxis = d3.axisRight(yAxis_scale)
-                .ticks(Math.floor(mainHeight / 20))
-                .tickSize(0)
-                .tickFormat(d => `${d}x`);
-
-            // Append Y-axis (done inside of the logic so that we can also add our rectangles)
-            svg.append('g')
-                .attr('class', 'y-axis')
-                .attr('transform', `translate(${margin.left}, ${margin.top})`)
-                .call(yAxis);
-            
-            // Add rectangles for the y-axis
-            let ticks = svg.selectAll('.tick')
-            
-            // Add rectangles for each tick
-            ticks.each(function(d, i) {
-                const tick = d3.select(this);
-                const text = tick.select('text');
-
-                //the rect should just be where the text is
-                const rectWidth = text.node().getBBox().width + 10;
-                const rectHeight = 10;
-                const rectX = parseFloat(text.attr('x')) - rectWidth / 2;
-
-                tick.append('rect')
-                    .attr('class', 'tick-rect')
-                    .attr('x', `${rectX + 6}`)
-                    .attr('y', `-${rectHeight/2}`)
-                    .attr('width', rectWidth)
-                    .attr('height', rectHeight)
-                    .attr('fill', 'white')
-                    .attr('opacity', 0.5)
-                    .attr('rx', 3);
-                
-                //Raise the text above the rectangle
-                text.raise();
-            });
-
-        } else {
-            // Y-axis
-            yAxis = d3.axisLeft(yAxis_scale)
+        if (opts.showYAxis) {
+            if (opts.yAxisPosition && opts.yAxisPosition === 'internal') {
+                // Y-axis
+                yAxis = d3.axisRight(yAxis_scale)
                     .ticks(Math.floor(mainHeight / 20))
                     .tickSize(0)
                     .tickFormat(d => `${d}x`);
-            
-            // Append Y-axis 
-            svg.append('g')
-                .attr('class', 'y-axis')
-                .attr('transform', `translate(${margin.left}, ${margin.top})`)
-                .call(yAxis); 
+
+                // Append Y-axis (done inside of the logic so that we can also add our rectangles)
+                svg.append('g')
+                    .attr('class', 'y-axis')
+                    .attr('transform', `translate(${margin.left}, ${margin.top})`)
+                    .call(yAxis);
+                
+                // Add rectangles for the y-axis
+                let ticks = svg.selectAll('.tick')
+                
+                // Add rectangles for each tick
+                ticks.each(function(d, i) {
+                    const tick = d3.select(this);
+                    const text = tick.select('text');
+
+                    //the rect should just be where the text is
+                    const rectWidth = text.node().getBBox().width + 10;
+                    const rectHeight = 10;
+                    const rectX = parseFloat(text.attr('x')) - rectWidth / 2;
+
+                    tick.append('rect')
+                        .attr('class', 'tick-rect')
+                        .attr('x', `${rectX + 6}`)
+                        .attr('y', `-${rectHeight/2}`)
+                        .attr('width', rectWidth)
+                        .attr('height', rectHeight)
+                        .attr('fill', 'white')
+                        .attr('opacity', 0.5)
+                        .attr('rx', 3);
+                    
+                    //Raise the text above the rectangle
+                    text.raise();
+                });
+
+            } else {
+                // Y-axis
+                yAxis = d3.axisLeft(yAxis_scale)
+                        .ticks(Math.floor(mainHeight / 20))
+                        .tickSize(0)
+                        .tickFormat(d => `${d}x`);
+                
+                // Append Y-axis 
+                svg.append('g')
+                    .attr('class', 'y-axis')
+                    .attr('transform', `translate(${margin.left}, ${margin.top})`)
+                    .call(yAxis); 
+            }
+
+            //If we dont want to see or render the y axis main line 
+            if (opts.showYAxisLine == false) {
+                svg.selectAll('.domain').remove();
+            }
         }
 
         const meanLineGroup = svg.append('g')

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -1,7 +1,6 @@
 import * as d3 from 'd3';
 
-function createBamView(bamHeader, data, container) {
-
+function createBamView(bamHeader, data, container, options={}) {
     let xScale, yScale, xNavScale, yNavScale, svg, main, nav, color, brush, brushGroup, yAxis,
         margin, margin2, mainHeight, navHeight, innerWidth, innerHeight;
 
@@ -14,6 +13,7 @@ function createBamView(bamHeader, data, container) {
         return acc;
     }, {});
 
+    const opts = options;
 
     function createSvg() {
         d3.select(container).selectAll("*").remove();

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -370,7 +370,6 @@ function createBamView(bamHeader, data, container, options={}) {
                     .range([mainHeight, 0])
                     .domain([0, 2 * average / conversionRatio]);
 
-        console.log(opts.yAxisPosition);
         if (opts.yAxisPosition && opts.yAxisPosition === 'internal') {
             // Y-axis
             yAxis = d3.axisRight(yAxis_scale)
@@ -399,8 +398,8 @@ function createBamView(bamHeader, data, container, options={}) {
 
                 tick.append('rect')
                     .attr('class', 'tick-rect')
-                    .attr('x', `${rectX + 6}px`)
-                    .attr('y', `-${rectHeight/2}px`)
+                    .attr('x', `${rectX + 6}`)
+                    .attr('y', `-${rectHeight/2}`)
                     .attr('width', rectWidth)
                     .attr('height', rectHeight)
                     .attr('fill', 'white')

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -440,16 +440,49 @@ function createBamView(bamHeader, data, container, options={}) {
             .attr('stroke-dasharray', '3,3')
             .attr('z-index', 1000);
 
-        // label for mean line
-        meanLineGroup.append('text')
-            .attr('class', 'mean-label')
-            .attr('x', 0)
-            .attr('y', yAxis_scale(meanCoverage))
-            .attr('dy', "0.35em") 
-            .attr('text-anchor', 'end') 
-            .style('fill', 'red') 
-            .text(`${meanCoverage}x`)
-            .style('font-size', '12px');           
+        if (opts.averageCovLabelPosition && (opts.averageCovLabelPosition === 'right-internal' || opts.averageCovLabelPosition === 'left-internal')) {
+            meanLineGroup.append('rect')
+                .attr('x', function() {
+                    if (opts.averageCovLabelPosition === 'left-internal') {
+                        return 25 - 2; // 2px offset for the rectangle vs text
+                    } else if (opts.averageCovLabelPosition === 'right-internal') {
+                        return innerWidth - 32 - 2; // 2px offset for the rectangle vs text
+                    }
+                })
+                .attr('y', yAxis_scale(meanCoverage) - 7.5)
+                .attr('width', 25)
+                .attr('height', 15)
+                .style('fill', 'white')
+                .style('opacity', 0.7)
+                .attr('rx', 3);
+
+            // label for mean line
+            meanLineGroup.append('text')
+                .attr('class', 'mean-label')
+                .attr('x', function() {
+                    if (opts.averageCovLabelPosition === 'left-internal') {
+                        return 25;
+                    } else if (opts.averageCovLabelPosition === 'right-internal') {
+                        return innerWidth - 32;
+                    }
+                })
+                .attr('y', yAxis_scale(meanCoverage))
+                .attr('dy', "0.35em") 
+                .style('fill', 'red') 
+                .text(`${meanCoverage}x`)
+                .style('font-size', '12px');    
+        } else {
+            // label for mean line
+            meanLineGroup.append('text')
+                .attr('class', 'mean-label')
+                .attr('x', 0)
+                .attr('y', yAxis_scale(meanCoverage))
+                .attr('dy', "0.35em") 
+                .attr('text-anchor', 'end') 
+                .style('fill', 'red') 
+                .text(`${meanCoverage}x`)
+                .style('font-size', '12px');    
+        }
     }
 
 

--- a/coverage/src/BamViewChart.js
+++ b/coverage/src/BamViewChart.js
@@ -346,12 +346,21 @@ function createBamView(bamHeader, data, container, options={}) {
         const yAxis_scale = d3.scaleLinear()
                     .range([mainHeight, 0])
                     .domain([0, 2 * average / conversionRatio]);
-
-        // Y-axis
-        yAxis = d3.axisLeft(yAxis_scale)
+        
+        if (opts.yAxisPosition && opts.yAxisPosition === 'right') {
+            // Y-axis
+            yAxis = d3.axisRight(yAxis_scale)
                 .ticks(Math.floor(mainHeight / 20))
                 .tickSize(0)
                 .tickFormat(d => `${d}x`);
+
+        } else {
+            // Y-axis
+            yAxis = d3.axisLeft(yAxis_scale)
+                .ticks(Math.floor(mainHeight / 20))
+                .tickSize(0)
+                .tickFormat(d => `${d}x`);
+        }
 
         // Append Y-axis
         svg.append('g')
@@ -375,10 +384,42 @@ function createBamView(bamHeader, data, container, options={}) {
             .attr('stroke-dasharray', '3,3')
             .attr('z-index', 1000);
 
+        // If we are on the inside of the chart we need to add a white rectangle behind the mean line label
+        if (opts.averageCovLabelPosition === 'left-inside' || opts.averageCovLabelPosition === 'right-inside') {
+            meanLineGroup.append('rect')
+                .attr('x', function() {
+                    if (opts.averageCovLabelPosition === 'left-inside') {
+                        return 10 + 'px';
+                    } else if (opts.averageCovLabelPosition === 'right-inside') {
+                        return innerWidth - 32 + 'px';
+                    }
+                })
+                .attr('y', yAxis_scale(meanCoverage) - 10)
+                .attr('width', 25)
+                .attr('height', 20)
+                .style('fill', 'white')
+                .style('opacity', 0.7)
+                .attr('rx', 5);
+        }
+
         // label for mean line
         meanLineGroup.append('text')
             .attr('class', 'mean-label')
-            .attr('x', 0)
+            .attr('x', function() {
+                if (opts.averageCovLabelPosition) {
+                    if (opts.averageCovLabelPosition === 'left-outside') {
+                        return 0 + 'px';
+                    } else if (opts.averageCovLabelPosition === 'right-outside') {
+                        return innerWidth + 'px';
+                    } else if (opts.averageCovLabelPosition === 'left-inside') {
+                        return 10 + 'px';
+                    } else if (opts.averageCovLabelPosition === 'right-inside') {
+                        return innerWidth - 10 + 'px';
+                    }
+                } else {
+                    return 0 + 'px';
+                }
+            })
             .attr('y', yAxis_scale(meanCoverage))
             .attr('dy', "0.35em") 
             .attr('text-anchor', 'end') 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobio-charts",
-  "version": "0.18.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobio-charts",
-      "version": "0.17.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0"


### PR DESCRIPTION
This adds some advanced options to the chart to allow optional/modified rendering of some elements:
- chart label
- zoom/brush-able chart
- chromosome upper section
- y axis
- y axis position
- y axis label
- coverage line label position
- customizable margin

This component should remain backwards compatible via the "default" options being defined. The user should need only to pass the options they would like to change via `compontentName.options = options;`

If the user passes incorrect options the chart should render a default state. Although, this isn't explicitly controlled on "input" we certainly could if that were preferred. 

All of these "advanced options" are passed as one object we could rethink that if you wanted to.
